### PR TITLE
CAF-1914 Updating versions from 1.0.1-SNAPSHOT to 1.1.0-SNAPSHOT

### DIFF
--- a/caf-api/pom.xml
+++ b/caf-api/pom.xml
@@ -20,12 +20,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>caf-api</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.github.cafapi.util</groupId>
             <artifactId>util-naming</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/caf-parent/pom.xml
+++ b/caf-parent/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>caf-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencyManagement>
@@ -565,7 +565,7 @@
                     <plugin>
                         <groupId>com.hpe.caf</groupId>
                         <artifactId>caf-kafka-istf-maven-plugin</artifactId>
-                        <version>1.0.0-SNAPSHOT</version>
+                        <version>1.0.0</version>
                         <executions>
                             <execution>
                                 <id>istf-upload</id>
@@ -580,9 +580,9 @@
             </build>
             <dependencies>
                 <dependency>
-                    <groupId>com.hpe.qa.test.framework.listeners</groupId>
-                    <artifactId>testng_sqlreporter</artifactId>
-                    <version>2.0.0-SNAPSHOT</version>
+                    <groupId>com.hpe.caf.qa.test.framework.listeners</groupId>
+                    <artifactId>caf-testng-sqlreporter</artifactId>
+                    <version>1.0.0</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/caf-utils/pom.xml
+++ b/caf-utils/pom.xml
@@ -20,12 +20,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>caf-utils</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -33,17 +33,17 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.cafapi.util</groupId>
             <artifactId>util-moduleloader</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.cafapi.config</groupId>
             <artifactId>config-system</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/cipher-jasypt/pom.xml
+++ b/cipher-jasypt/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.cipher</groupId>
     <artifactId>cipher-jasypt</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/cipher-null/pom.xml
+++ b/cipher-null/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.cipher</groupId>
     <artifactId>cipher-null</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/codec-json-lzf/pom.xml
+++ b/codec-json-lzf/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.codec</groupId>
     <artifactId>codec-json-lzf</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,13 +34,13 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.cafapi.codec</groupId>
             <artifactId>codec-json</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/codec-json/pom.xml
+++ b/codec-json/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.codec</groupId>
     <artifactId>codec-json</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/codec-yaml/pom.xml
+++ b/codec-yaml/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.codec</groupId>
     <artifactId>codec-yaml</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/config-caf/pom.xml
+++ b/config-caf/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.config</groupId>
     <artifactId>config-caf</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/config-file/pom.xml
+++ b/config-file/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.config</groupId>
     <artifactId>config-file</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.cafapi.config</groupId>
             <artifactId>config-caf</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.github.cafapi.codec</groupId>
             <artifactId>codec-yaml</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.github.cafapi.cipher</groupId>
             <artifactId>cipher-null</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/config-rest/pom.xml
+++ b/config-rest/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.config</groupId>
     <artifactId>config-rest</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,13 +34,13 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.cafapi.config</groupId>
             <artifactId>config-caf</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.github.cafapi.codec</groupId>
             <artifactId>codec-json</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.github.cafapi.cipher</groupId>
             <artifactId>cipher-null</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/config-system/pom.xml
+++ b/config-system/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.config</groupId>
     <artifactId>config-system</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/container-cert-script/pom.xml
+++ b/container-cert-script/pom.xml
@@ -20,13 +20,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>container-cert-script</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 

--- a/election-null/pom.xml
+++ b/election-null/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.election</groupId>
     <artifactId>election-null</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.cafapi</groupId>
             <artifactId>caf-api</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.cafapi</groupId>
     <artifactId>caf-common</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/release-notes-1.1.0.md
+++ b/release-notes-1.1.0.md
@@ -1,5 +1,6 @@
 #### New Features
 [CAF-1853](https://jira.autonomy.com/browse/CAF-1853): Allow configuration files to read from environment variables
+[CAF-1830](https://jira.autonomy.com/browse/CAF-1830): Update to Liquibase Installer
 
 #### Known Issues
 None

--- a/swagger-ui/pom.xml
+++ b/swagger-ui/pom.xml
@@ -20,13 +20,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>swagger-ui</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 

--- a/util-jerseycompat/pom.xml
+++ b/util-jerseycompat/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.util</groupId>
     <artifactId>util-jerseycompat</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 

--- a/util-liquibase-installer/pom.xml
+++ b/util-liquibase-installer/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
     <groupId>com.github.cafapi.util</groupId>
     <artifactId>util-liquibase-installer</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/util-moduleloader/pom.xml
+++ b/util-moduleloader/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.util</groupId>
     <artifactId>util-moduleloader</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 

--- a/util-naming/pom.xml
+++ b/util-naming/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.github.cafapi.util</groupId>
     <artifactId>util-naming</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 

--- a/util-process-identifier/pom.xml
+++ b/util-process-identifier/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 
     <groupId>com.github.cafapi.util</groupId>
     <artifactId>util-process-identifier</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/util-ref/pom.xml
+++ b/util-ref/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>com.github.cafapi.util</groupId>
     <artifactId>util-ref</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../caf-parent</relativePath>
     </parent>
 


### PR DESCRIPTION
Updating versions in preparation for the first automated release of caf-common.
This includes a move to released version of:
- caf-testng-sqlreporter:1.0.0
- caf-kafka-istf-maven-plugin:1.0.0