### PR TITLE
Adding powermock specific version dependencies to dependency management.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,12 +543,12 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
+                <artifactId>powermock-api-mockito</artifactId>
                 <version>1.6.4</version>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
+                <artifactId>powermock-module-junit4</artifactId>
                 <version>1.6.4</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,16 @@
                 <version>1.10.19</version>
             </dependency>
             <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>1.6.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>1.6.4</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.10</version>


### PR DESCRIPTION
@dermot-hardy Will avoid projects specifying their own versions and being on slightly different versions.