### PR TITLE
CAF-2284: Ignore test resources when scanning for license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -745,6 +745,7 @@ limitations under the License.
                         <exclude>**/test-configs/**</exclude>
                         <exclude>**/test-data/**</exclude>
                         <exclude>**/test-license/**</exclude>
+                        <exclude>src/test/resources/**</exclude>
                     </excludes>
                     <mapping>
                         <java>PHP</java>


### PR DESCRIPTION
Ignore test/resources when scanning for license headers.
Binary files / content used in unit testing may not require our header, they may be test docx files or something used for test comparisons only.