### PR TITLE
License plugin update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,7 +746,7 @@ limitations under the License.
                         <exclude>**/test-configs/**</exclude>
                         <exclude>**/test-data/**</exclude>
                         <exclude>**/test-license/**</exclude>
-						<exclude>**/resources/**</exclude>
+                        <exclude>**/resources/**</exclude>
                     </excludes>
                     <mapping>
                         <java>PHP</java>

--- a/pom.xml
+++ b/pom.xml
@@ -746,6 +746,7 @@ limitations under the License.
                         <exclude>**/test-configs/**</exclude>
                         <exclude>**/test-data/**</exclude>
                         <exclude>**/test-license/**</exclude>
+						<exclude>**/resources/**</exclude>
                     </excludes>
                     <mapping>
                         <java>PHP</java>


### PR DESCRIPTION
This change is to force the mycila-license-plugin to ignore the resources folder in some projects when updating files with license headers.

This is to correct an issue where some test .txt files contained within "resources" were being updated with the license header. When it came to running the integration tests the comments were being read as part of the text to test rather than being scanned over, causing the tests to fail.

This can be seen in language-detection-cld2.

Other open-sourced projects have had test files within the resources folder updated with the license header, but they were not .txt files, which seem to get around this issue.