### PR TITLE
CAF-2675: Add jcl-over-slf4j to dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,12 +576,12 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
+                <artifactId>jcl-over-slf4j</artifactId>
                 <version>1.7.10</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
+                <artifactId>slf4j-api</artifactId>
                 <version>1.7.10</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,11 @@
                 <version>1.7.10</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>1.7.10</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>6.4</version>

--- a/release-notes-1.11.0.md
+++ b/release-notes-1.11.0.md
@@ -4,6 +4,6 @@
 ${version-number}
 
 #### New Features
-[CAF-2675](https://jira.autonomy.com/browse/CAF-2675): Add jcl-over-slf4j to common dependency management.
+[CAF-2675](https://jira.autonomy.com/browse/CAF-2675): Updated dependency management to include jcl-over-slf4j
 
 #### Known Issues

--- a/release-notes-1.11.0.md
+++ b/release-notes-1.11.0.md
@@ -4,5 +4,6 @@
 ${version-number}
 
 #### New Features
+[CAF-2675](https://jira.autonomy.com/browse/CAF-2675): Add jcl-over-slf4j to common dependency management.
 
 #### Known Issues


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2675