### PR TITLE
CAF-2915: Adding java-postgres image to caf-common.

### DIFF
--- a/java-postgres-container/README.md
+++ b/java-postgres-container/README.md
@@ -1,0 +1,7 @@
+# java-postgres-container
+
+---
+
+A Docker container with PostgreSQL 9.4 and the Java 8 runtime environment installed. 
+
+The image is built from the postgres docker image postgres:9.4.10-alpine in the official Docker repository [here](https://hub.docker.com/_/postgres/). The configuration and run instructions for the base image are also applicable to this image. OpenJDK JRE 8 is installed as part of the container build.

--- a/java-postgres-container/pom.xml
+++ b/java-postgres-container/pom.xml
@@ -49,6 +49,22 @@
                             <skip>false</skip>
                         </configuration>
                     </execution>
+                    <!-- Start the containers in pre-integration-test phase. -->
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <!-- Stop the containers in post-integration-test phase. -->
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <phase>deploy</phase>
                         <goals>

--- a/java-postgres-container/pom.xml
+++ b/java-postgres-container/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi</groupId>
+        <artifactId>caf-common</artifactId>
+        <version>1.11.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.hpe.caf</groupId>
+    <artifactId>java-postgres-container</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${fabric8.docker.maven.version}</version>
+                <executions>
+                    <execution>
+                        <id>build-container</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
+                        <configuration>
+                            <filter>java-postgres</filter>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <verbose>true</verbose>
+                    <autoPull>always</autoPull>
+                    <images>
+                        <image>
+                            <alias>java-postgres</alias>
+                            <name>cafinternal/java-postgres:${project.version}</name>
+                            <build>
+                                <from>postgres:9.4.10-alpine</from>
+                                <labels>
+                                    <Build.Number>${project.version}</Build.Number>
+                                    <Build.Date>${maven.build.timestamp}</Build.Date>
+                                    <Git.Branch>${git.branch}</Git.Branch>
+                                    <Git.Commit>${git.revision}</Git.Commit>
+                                </labels>
+                                <optimise>false</optimise>
+                                <runCmds>
+                                    <runCmd>apk --update add openjdk8-jre</runCmd>
+                                </runCmds>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>${postgres.db.port}:5432</port>
+                                </ports>
+                                <env>
+                                    <POSTGRES_PASSWORD>root</POSTGRES_PASSWORD>
+                                    <POSTGRES_USER>postgres</POSTGRES_USER>
+                                </env>
+                                <wait>
+                                    <log>PostgreSQL init process complete</log>
+                                    <time>120000</time>
+                                    <shutdown>500</shutdown>
+                                </wait>
+                                <log>
+                                    <enabled>true</enabled>
+                                </log>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>use-default-fixed-ports</id>
+            <properties>
+                <postgres.db.port>5432</postgres.db.port>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/java-postgres-container/pom.xml
+++ b/java-postgres-container/pom.xml
@@ -65,7 +65,7 @@
                     <images>
                         <image>
                             <alias>java-postgres</alias>
-                            <name>cafinternal/java-postgres:${project.version}</name>
+                            <name>cafinternal/prereleases:java-postgres-${project.version}</name>
                             <build>
                                 <from>postgres:9.4.10-alpine</from>
                                 <labels>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             <email>michael.bryson@hpe.com</email>
         </developer>
         <developer>
+            <id>mmaBel</id>
+            <name>Michael McAlynn</name>
+            <email>michael.mcalynn@hpe.com</email>
+        </developer>
+        <developer>
             <id>mulhollandc</id>
             <name>Connor Mulholland</name>
             <email>connor.mulholland@hpe.com</email>
@@ -113,6 +118,7 @@
         <module>container-cert-script</module>
         <module>decoder-js</module>
         <module>election-null</module>
+        <module>java-postgres-container</module>
         <module>swagger-restapi-client-base</module>
         <module>swagger-ui</module>
         <module>util-ref</module>

--- a/release-notes-1.11.0.md
+++ b/release-notes-1.11.0.md
@@ -5,5 +5,6 @@ ${version-number}
 
 #### New Features
 [CAF-2675](https://jira.autonomy.com/browse/CAF-2675): Updated dependency management to include jcl-over-slf4j and postgresql JDBC driver.
+[CAF-2915](https://jira.autonomy.com/browse/CAF-2675): Adding java-postgres-container to caf-common. A docker container with postgres 9.4 and Java 8 installed.
 
 #### Known Issues


### PR DESCRIPTION
This seems a sensible place for this image. It will be consumed by both data processing and job service.