### PR TITLE
CAF-3173: Addition of new dependencies from CAF-Storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,12 +513,12 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.0</version>
+                <version>2.8.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.0</version>
+                <version>2.8.2</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
@@ -593,12 +593,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
-                <version>1.7.10</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.10</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,11 @@
                 <version>1.1.0.Final</version>
             </dependency>
             <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>2.0.1</version>
+            </dependency>
+            <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
                 <version>2.8.2</version>
@@ -594,6 +599,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j-version}</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>


### PR DESCRIPTION
Addition of new dependencies that are being used in CAF-Storage
* javax-ws-rs-api
* slf4j-log4j12

Other dependencies being utilised by CAF-Storage are either already present in CAF-Common or are being made exclusive for use by CAF-Storage (eclipse-link-version, javax-persistence)