### PR TITLE
Support alternate Tomcat location in keystore script

### DIFF
--- a/container-cert-script/install-keystore-tomcat.sh
+++ b/container-cert-script/install-keystore-tomcat.sh
@@ -17,8 +17,15 @@
 
 if [ -n "${SSL_KEYSTORE_PASSWORD}" ]
 then
-    echo "Setting keystore password in /usr/local/tomcat/conf/server.xml"
-    sed -i 's/\(keystorePass\)="[^"]*"/\1='\"${SSL_KEYSTORE_PASSWORD}\"'/' /usr/local/tomcat/conf/server.xml
+    if [ -e /usr/local/tomcat/conf/server.xml ]; then
+        echo "Setting keystore password in /usr/local/tomcat/conf/server.xml"
+        sed -i 's/\(keystorePass\)="[^"]*"/\1='\"${SSL_KEYSTORE_PASSWORD}\"'/' /usr/local/tomcat/conf/server.xml
+    elif [ -e /usr/share/tomcat/conf/server.xml ]; then
+        echo "Setting keystore password in /usr/share/tomcat/conf/server.xml"
+        sed -i 's/\(keystorePass\)="[^"]*"/\1='\"${SSL_KEYSTORE_PASSWORD}\"'/' /usr/share/tomcat/conf/server.xml
+    else
+        echo "WARNING: Couldn't locate Tomcat server.xml file"
+    fi
 else
     echo "Not setting keystore password"
 fi

--- a/release-notes-1.15.0.md
+++ b/release-notes-1.15.0.md
@@ -1,8 +1,9 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
 #### New Features
+ - Added support for alternate Tomcat location  
+    The `install-keystore-tomcat.sh` script has been updated to support `/usr/share/tomcat` as an alternative installation location for Tomcat.  Previously the only installation location supported by the script was `/usr/local/tomcat`.
 
 #### Known Issues
+ - None


### PR DESCRIPTION
The openSUSE-based containers install Tomcat to `/usr/share` rather than `/usr/local`.