### PR TITLE
SCMOD-7738 Removing keyview-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
             <dependency>
                 <groupId>com.microfocus.caf.keyview</groupId>
                 <artifactId>keyview-api-12.4.0</artifactId>
-		        <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -319,11 +319,6 @@
                 <version>${sunJerseyVersion}</version>
             </dependency>
             <dependency>
-                <groupId>com.microfocus.caf.keyview</groupId>
-                <artifactId>keyview-api-12.4.0</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -319,9 +319,9 @@
                 <version>${sunJerseyVersion}</version>
             </dependency>
             <dependency>
-                <groupId>com.verity</groupId>
-                <artifactId>keyview-api</artifactId>
-                <version>11.2.0</version>
+                <groupId>com.microfocus.caf.keyview</groupId>
+                <artifactId>keyview-api-12.4.0</artifactId>
+		        <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
keyview-api is only used by worker-textextract, caf-common dependencies should only be used by modules in caf-common, so removing the dependency here and adding it to worker-textextract (will be in a separate PR)